### PR TITLE
fix(oo): --help flag routes to help handler across all specialists

### DIFF
--- a/agents/cs/dispatcher.py
+++ b/agents/cs/dispatcher.py
@@ -43,6 +43,8 @@ class CSDispatcher(AgentBase):
         parts = text_in.split(maxsplit=1)
         cmd = parts[0].lower()
         rest = parts[1].strip() if len(parts) > 1 else ""
+        if cmd in ("--help", "-h"):
+            cmd = "help"
 
         if cmd == "help":
             return {"text": HELP_TEXT}

--- a/agents/cs/tests/test_dispatcher.py
+++ b/agents/cs/tests/test_dispatcher.py
@@ -26,6 +26,18 @@ async def test_help_returns_command_list(cs_payload):
 
 
 @pytest.mark.asyncio
+async def test_help_long_flag_routes_to_help(cs_payload):
+    result = await CSDispatcher().handle("slack", cs_payload(text="--help"))
+    assert result["text"] == HELP_TEXT
+
+
+@pytest.mark.asyncio
+async def test_help_short_flag_routes_to_help(cs_payload):
+    result = await CSDispatcher().handle("slack", cs_payload(text="-h"))
+    assert result["text"] == HELP_TEXT
+
+
+@pytest.mark.asyncio
 async def test_unknown_command_shows_help(cs_payload):
     result = await CSDispatcher().handle("slack", cs_payload(text="frobnicate"))
     assert "unknown cs command" in result["text"].lower()

--- a/agents/onboarding/dispatcher.py
+++ b/agents/onboarding/dispatcher.py
@@ -55,6 +55,8 @@ class OnboardingDispatcher(AgentBase):
         parts = text_in.split(maxsplit=1)
         cmd = parts[0].lower()
         rest = parts[1].strip() if len(parts) > 1 else ""
+        if cmd in ("--help", "-h"):
+            cmd = "help"
 
         if cmd == "help":
             return {"text": HELP_TEXT}

--- a/agents/onboarding/tests/test_dispatcher.py
+++ b/agents/onboarding/tests/test_dispatcher.py
@@ -26,6 +26,18 @@ async def test_help_returns_command_list(ob_payload):
 
 
 @pytest.mark.asyncio
+async def test_help_long_flag_routes_to_help(ob_payload):
+    result = await OnboardingDispatcher().handle("slack", ob_payload(text="--help"))
+    assert result["text"] == HELP_TEXT
+
+
+@pytest.mark.asyncio
+async def test_help_short_flag_routes_to_help(ob_payload):
+    result = await OnboardingDispatcher().handle("slack", ob_payload(text="-h"))
+    assert result["text"] == HELP_TEXT
+
+
+@pytest.mark.asyncio
 async def test_unknown_command_shows_help(ob_payload):
     result = await OnboardingDispatcher().handle("slack", ob_payload(text="frobnicate"))
     assert "unknown onboarding command" in result["text"].lower()

--- a/agents/revops_support/agent.py
+++ b/agents/revops_support/agent.py
@@ -50,7 +50,7 @@ class RevOpsSupportAgent(AgentBase):
             return {"text": "pong — RevOps Support online."}
 
         lower = text_in.lower()
-        if lower == "help":
+        if lower in ("help", "--help", "-h"):
             return {"text": HELP_TEXT}
 
         # Phrase-based matching for natural commands. Order matters — more

--- a/agents/revops_support/tests/test_agent_handle.py
+++ b/agents/revops_support/tests/test_agent_handle.py
@@ -24,6 +24,22 @@ async def test_help_returns_command_list():
 
 
 @pytest.mark.asyncio
+async def test_help_long_flag_routes_to_help():
+    agent = RevOpsSupportAgent()
+    result = await agent.handle("slack", {"text": "--help"})
+    assert "pipeline by stage" in result["text"]
+    assert "Unknown" not in result["text"]
+
+
+@pytest.mark.asyncio
+async def test_help_short_flag_routes_to_help():
+    agent = RevOpsSupportAgent()
+    result = await agent.handle("slack", {"text": "-h"})
+    assert "pipeline by stage" in result["text"]
+    assert "Unknown" not in result["text"]
+
+
+@pytest.mark.asyncio
 async def test_pipeline_by_stage_routes_to_canned():
     agent = RevOpsSupportAgent()
     with patch("agents.revops_support.agent.canned.pipeline_by_stage") as mock_fn:

--- a/agents/sales_reps/handler.py
+++ b/agents/sales_reps/handler.py
@@ -36,7 +36,11 @@ class SalesRepsAgent(AgentBase):
             return {"text": "pong — sales_reps online."}
 
         cmd, _, rest = text_in.partition(" ")
-        cmd = cmd.lower().replace("-", "_")
+        cmd_lower = cmd.lower()
+        if cmd_lower in ("--help", "-h"):
+            cmd = "help"
+        else:
+            cmd = cmd_lower.replace("-", "_")
 
         handler = _SUBCOMMANDS.get(cmd)
         if handler is None:

--- a/agents/sales_reps/tests/test_handler.py
+++ b/agents/sales_reps/tests/test_handler.py
@@ -38,6 +38,18 @@ def test_help_command():
     assert "leaderboard" in out["text"]
 
 
+def test_help_long_flag_routes_to_help():
+    out = asyncio.run(SalesRepsAgent().run("test", {"text": "--help"}))
+    assert "scorecard" in out["text"]
+    assert "unknown" not in out["text"].lower()
+
+
+def test_help_short_flag_routes_to_help():
+    out = asyncio.run(SalesRepsAgent().run("test", {"text": "-h"}))
+    assert "scorecard" in out["text"]
+    assert "unknown" not in out["text"].lower()
+
+
 # ---------- subcommand routing into stubs ----------
 
 def test_grade_requires_meeting_id():

--- a/agents/slt_metrics/dispatcher.py
+++ b/agents/slt_metrics/dispatcher.py
@@ -22,7 +22,11 @@ async def route(agent: SltMetricsAgent, trigger: str, payload: dict[str, Any]) -
         return {"text": "pong — slt_metrics online."}
 
     cmd, _, rest = text_in.partition(" ")
-    cmd = cmd.lower().replace("-", "_")
+    cmd_lower = cmd.lower()
+    if cmd_lower in ("--help", "-h"):
+        cmd = "help"
+    else:
+        cmd = cmd_lower.replace("-", "_")
 
     handler = _SUBCOMMANDS.get(cmd)
     if handler is None:

--- a/agents/slt_metrics/tests/test_dispatcher_routing.py
+++ b/agents/slt_metrics/tests/test_dispatcher_routing.py
@@ -42,6 +42,18 @@ def test_help_command():
     assert "backtest" in out["text"]
 
 
+def test_help_long_flag_routes_to_help():
+    out = asyncio.run(SltMetricsAgent().run("test", {"text": "--help"}))
+    assert "forecast" in out["text"]
+    assert "unknown" not in out["text"].lower()
+
+
+def test_help_short_flag_routes_to_help():
+    out = asyncio.run(SltMetricsAgent().run("test", {"text": "-h"}))
+    assert "forecast" in out["text"]
+    assert "unknown" not in out["text"].lower()
+
+
 # ---------- subcommand routing into stubs ----------
 
 def test_forecast_requires_quarter():

--- a/agents/top_of_funnel/handler.py
+++ b/agents/top_of_funnel/handler.py
@@ -33,7 +33,11 @@ class TopOfFunnelAgent(AgentBase):
             return {"text": "pong — top_of_funnel online."}
 
         cmd, _, rest = text_in.partition(" ")
-        cmd = cmd.lower().replace("-", "_")
+        cmd_lower = cmd.lower()
+        if cmd_lower in ("--help", "-h"):
+            cmd = "help"
+        else:
+            cmd = cmd_lower.replace("-", "_")
 
         handler = _SUBCOMMANDS.get(cmd)
         if handler is None:

--- a/agents/top_of_funnel/tests/test_dispatch.py
+++ b/agents/top_of_funnel/tests/test_dispatch.py
@@ -58,6 +58,22 @@ async def test_help_explicit():
     assert "credits" in r["text"]
 
 
+@pytest.mark.asyncio
+async def test_help_long_flag_routes_to_help():
+    a = TopOfFunnelAgent()
+    r = await a.handle("slack", {"text": "--help"})
+    assert "enrich" in r["text"]
+    assert "Unknown" not in r["text"]
+
+
+@pytest.mark.asyncio
+async def test_help_short_flag_routes_to_help():
+    a = TopOfFunnelAgent()
+    r = await a.handle("slack", {"text": "-h"})
+    assert "enrich" in r["text"]
+    assert "Unknown" not in r["text"]
+
+
 # ---------------------------------------------------------- command routing
 
 


### PR DESCRIPTION
## Summary

- Intercepts `--help` and `-h` at the top of each specialist's command router and rewrites to `help` before any downstream normalization
- Applied across all six specialists (`top_of_funnel`, `sales_reps`, `slt_metrics`, `onboarding`, `cs`, `revops_support`) rather than just the five named in the issue, for consistency — see scope note below
- 12 new tests (2 per specialist, covering `--help` and `-h`), asserting help body renders and no "Unknown" prefix appears

Closes #1.

## Bug

`@Outbounder <specialist> --help` produced a spurious "Unknown command" line before the help text. Root cause varied by specialist:

| Specialist | Old behavior on `--help` |
|---|---|
| `top_of_funnel`, `sales_reps`, `slt_metrics` | `cmd.lower().replace("-", "_")` turned `--help` → `__help`, then emitted `Unknown command \`__help\`` |
| `onboarding`, `cs` | No dash normalization, but unknown-command path still fired — rendered `Unknown <x> command: \`--help\`` |
| `revops_support` | Unknown-command message omits the command text, so nothing looked ugly — but `--help` still fell through to unknown, not to help |

## Scope note

Issue #1 names five specialists. Code inspection showed `revops_support` was not actually handling `--help` — just had a cosmetically cleaner error. Fixing all six with one consistent pattern avoids a follow-up PR; the diff is three lines per specialist.

## Test plan

- [x] `pytest -q` — 1,485 passed, 6 skipped (baseline 1,473 + 12 new)
- [x] Unit tests added for `--help` and `-h` in all six specialist test files
- [ ] Live verification on OO daemon after PR merges (deferred — soak active until 2026-04-15, do NOT merge yet)

## Soak status

Main is frozen for the Phase 1 24h soak ending 2026-04-15. This PR is branch-only and should not merge until soak sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)