### PR TITLE
feat(dispatcher): persona-name aliases for the 6 specialists

### DIFF
--- a/agents/cs/dispatcher.py
+++ b/agents/cs/dispatcher.py
@@ -23,7 +23,8 @@ HELP_TEXT = (
     "• `@oo cs renewals` — T-120 window + stalls\n"
     "• `@oo cs churn-risk [50|70|85]` — scored accounts\n"
     "• `@oo cs brief <account>` — pre-renewal brief\n"
-    "• `@oo cs qbr <account>` — QBR markdown"
+    "• `@oo cs qbr <account>` — QBR markdown\n"
+    "Alias: `@oo supporter …` routes here too."
 )
 
 

--- a/agents/cs/tests/test_dispatcher.py
+++ b/agents/cs/tests/test_dispatcher.py
@@ -85,3 +85,34 @@ async def test_registration_exposes_handler():
     # Dispatch should return our pong
     result = await slack_dispatcher.dispatch("cs ping", {"user": "U_TEST", "channel": "C_TEST"})
     assert "pong" in result["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_persona_alias_supporter_routes_to_cs():
+    """`@oo supporter ping` resolves through PERSONA_ALIASES to the cs handler."""
+    from agents.cs import main as cs_main
+    from shared import slack_dispatcher
+
+    cs_main.bootstrap()
+    result = await slack_dispatcher.dispatch(
+        "supporter ping", {"user": "U_TEST", "channel": "C_TEST"}
+    )
+    assert "pong" in result["text"].lower()
+    assert "cs online" in result["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_persona_alias_supporter_matches_canonical_help():
+    """Alias and canonical return identical help text."""
+    from agents.cs import main as cs_main
+    from shared import slack_dispatcher
+
+    cs_main.bootstrap()
+    alias = await slack_dispatcher.dispatch(
+        "supporter help", {"user": "U_TEST", "channel": "C_TEST"}
+    )
+    canonical = await slack_dispatcher.dispatch(
+        "cs help", {"user": "U_TEST", "channel": "C_TEST"}
+    )
+    assert alias["text"] == canonical["text"] == HELP_TEXT
+    assert "supporter" in alias["text"]

--- a/agents/onboarding/dispatcher.py
+++ b/agents/onboarding/dispatcher.py
@@ -34,7 +34,8 @@ HELP_TEXT = (
     "• `@oo onboarding handoff <account>` — run handoff checklist on demand\n"
     "• `@oo onboarding skip <opp_id> <justification>` — override a blocking handoff item\n"
     "• `@oo onboarding assign <gate_id> <user_id>` — complete an approved CSM reassignment\n"
-    "• `@oo onboarding backfill --preview` — count historical Closed Won gaps"
+    "• `@oo onboarding backfill --preview` — count historical Closed Won gaps\n"
+    "Alias: `@oo onboarder …` routes here too."
 )
 
 

--- a/agents/onboarding/tests/test_dispatcher.py
+++ b/agents/onboarding/tests/test_dispatcher.py
@@ -304,3 +304,35 @@ async def test_registration_exposes_handler():
         "onboarding ping", {"user": "U_TEST", "channel": "C_TEST"}
     )
     assert "pong" in result["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_persona_alias_onboarder_routes_to_onboarding():
+    """`@oo onboarder ping` resolves through PERSONA_ALIASES to the onboarding
+    handler."""
+    from agents.onboarding import main as ob_main
+    from shared import slack_dispatcher
+
+    ob_main.bootstrap()
+    result = await slack_dispatcher.dispatch(
+        "onboarder ping", {"user": "U_TEST", "channel": "C_TEST"}
+    )
+    assert "pong" in result["text"].lower()
+    assert "onboarding online" in result["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_persona_alias_onboarder_matches_canonical_help():
+    """Alias and canonical return identical help text."""
+    from agents.onboarding import main as ob_main
+    from shared import slack_dispatcher
+
+    ob_main.bootstrap()
+    alias = await slack_dispatcher.dispatch(
+        "onboarder help", {"user": "U_TEST", "channel": "C_TEST"}
+    )
+    canonical = await slack_dispatcher.dispatch(
+        "onboarding help", {"user": "U_TEST", "channel": "C_TEST"}
+    )
+    assert alias["text"] == canonical["text"] == HELP_TEXT
+    assert "onboarder" in alias["text"]

--- a/agents/revops_support/agent.py
+++ b/agents/revops_support/agent.py
@@ -32,7 +32,8 @@ HELP_TEXT = (
     "• `@oo revops-support duplicate contacts` — emails with >1 contact\n"
     "• `@oo revops-support active users` — users with login in last 30 days\n"
     "• `@oo revops-support validation rules <ObjectName>` — active rules for object\n"
-    "• `@oo revops-support help` — this message"
+    "• `@oo revops-support help` — this message\n"
+    "Alias: `@oo admin …` routes here too."
 )
 
 

--- a/agents/revops_support/tests/test_dispatcher_registration.py
+++ b/agents/revops_support/tests/test_dispatcher_registration.py
@@ -51,3 +51,31 @@ async def test_unregistered_specialist_still_routed_to_oo():
     )
     # OO's current fallback for unknown commands returns a "no handler wired" note.
     assert "received" in result["text"].lower() or "handler" in result["text"].lower() or "sales_reps" in result["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_persona_alias_admin_routes_to_revops_support():
+    """`@oo admin ping` resolves through PERSONA_ALIASES to the revops_support handler."""
+    register_with_dispatcher()
+    result = await slack_dispatcher.dispatch(
+        "<@U0BOT> admin ping",
+        context={"user": "U07P4GX9YLQ", "channel": "C_TEST"},
+    )
+    assert "pong" in result["text"].lower()
+    assert "revops support" in result["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_persona_alias_admin_matches_canonical_help():
+    """Alias and canonical return identical help text."""
+    register_with_dispatcher()
+    alias = await slack_dispatcher.dispatch(
+        "<@U0BOT> admin help",
+        context={"user": "U07P4GX9YLQ", "channel": "C_TEST"},
+    )
+    canonical = await slack_dispatcher.dispatch(
+        "<@U0BOT> revops_support help",
+        context={"user": "U07P4GX9YLQ", "channel": "C_TEST"},
+    )
+    assert alias["text"] == canonical["text"]
+    assert "admin" in alias["text"]

--- a/agents/sales_reps/handler.py
+++ b/agents/sales_reps/handler.py
@@ -133,4 +133,5 @@ def _help_text(unknown: str | None = None) -> str:
         "• `scorecard <rep_email>` — per-rep scorecard\n"
         "• `sync-check` — Momentum↔SF sync diff\n"
         "• `risk-sweep` — deal-risk signal sweep (pushed close, amount drop, competitor)\n"
+        "Alias: `@oo closer …` routes here too.\n"
     )

--- a/agents/sales_reps/tests/test_handler.py
+++ b/agents/sales_reps/tests/test_handler.py
@@ -196,6 +196,32 @@ def test_dispatch_via_underscore_form():
     assert "pong" in out["text"].lower()
 
 
+# ---------- persona alias ----------
+
+def test_persona_alias_closer_routes_to_sales_reps():
+    """`@oo closer ping` resolves through shared.slack_dispatcher.PERSONA_ALIASES
+    to the sales_reps handler."""
+    register_with_dispatcher()
+    out = asyncio.run(dispatch(
+        "<@BOTID> closer ping", {"user": "U123", "channel": "Cxx"}
+    ))
+    assert "pong" in out["text"].lower()
+    assert "sales_reps" in out["text"]
+
+
+def test_persona_alias_closer_matches_canonical_help():
+    """Alias and canonical produce identical help output."""
+    register_with_dispatcher()
+    alias = asyncio.run(dispatch(
+        "<@BOTID> closer help", {"user": "U123", "channel": "Cxx"}
+    ))
+    canonical = asyncio.run(dispatch(
+        "<@BOTID> sales_reps help", {"user": "U123", "channel": "Cxx"}
+    ))
+    assert alias["text"] == canonical["text"]
+    assert "closer" in alias["text"]
+
+
 # ---------- run() lifecycle writes to agent_runs ----------
 
 def test_agent_run_persists_to_db():

--- a/agents/slt_metrics/dispatcher.py
+++ b/agents/slt_metrics/dispatcher.py
@@ -202,4 +202,5 @@ def _help_text(unknown: str | None = None) -> str:
         "• `friday` — Friday 4 PM weekly review (DM draft to O)\n"
         "• `weights show|set|propose` — inspect / adjust forecast weights\n"
         "• `backtest <from> <to>` — replay scorer over a date range\n"
+        "Alias: `@oo urkel …` routes here too.\n"
     )

--- a/agents/slt_metrics/forecast/narrative.py
+++ b/agents/slt_metrics/forecast/narrative.py
@@ -4,14 +4,12 @@ Produces a Slack-blocks payload for O's DM when the SLT asks for a forecast
 ad-hoc via `@oo slt forecast <quarter>`. Parallel in spirit to
 `briefings.daily_830.compose_daily` but quarter-scoped instead of daily.
 
-Phase 1 note — this is a PLACEHOLDER narrative. The morning cron writes
-unscored snapshots until D6 wires `forecast.scorer.score_all`, so the commit
-/ best / weighted numbers come from whatever rows exist in
-`pipeline_snapshots` at invocation time. The Slack payload flags that
-explicitly so consumers (O → SLT) know it's first-gen until real scoring +
-narrator composition land. Swapping in a real narrative (Sonnet via
-`ClaudeRouter("adhoc_slt", ...)`) is a line change in `_narrative_block` —
-everything else in the forecast subcommand path stays the same.
+Narrative composition runs through `ClaudeRouter.narrate("adhoc_slt", ...)`
+(Sonnet, see `briefings/narrator.py`). If no API key is present or the call
+fails, the router returns the structural fallback — which still carries
+`PLACEHOLDER_TAG` while scoring is sparse, so consumers (O → SLT) know the
+commit / best / weighted numbers are first-gen until `forecast.scorer`
+backfills scores across the snapshot.
 """
 from __future__ import annotations
 
@@ -20,12 +18,23 @@ from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Any
 
+from agents.slt_metrics.briefings.narrator import ClaudeRouter
 from agents.slt_metrics.forecast import commit_best
 from agents.slt_metrics.pipeline import snapshotter
 from agents.slt_metrics.types import ForecastRollup, ScoredDeal
 
 
 PLACEHOLDER_TAG = "(placeholder narrative — pending forecast/narrative.py)"
+
+_ADHOC_SLT_SYSTEM = (
+    "You are Agent 6 (SLT Revenue Metrics) for Loop AI. "
+    "The SLT just asked for an ad-hoc forecast read. "
+    "Produce a 3-4 sentence narrative for Henry (CRO) and Anand (CEO): "
+    "lead with commit vs. best-case vs. weighted, then the most material "
+    "movement or risk across the scored deals. "
+    "If scoring is sparse or the snapshot is empty, caveat openly. "
+    "Plain text, no markdown, no emojis."
+)
 
 
 # Quarter tokens we accept. `Q2` implies current fiscal year (Loop AI FY ==
@@ -225,47 +234,90 @@ def _stale_block(ctx: ForecastDraftContext) -> dict[str, Any]:
     return {"type": "section", "text": {"type": "mrkdwn", "text": body}}
 
 
-def _narrative_block(ctx: ForecastDraftContext) -> dict[str, Any]:
-    """Placeholder narrative.
+def _narrative_block(ctx: ForecastDraftContext, *, router: ClaudeRouter) -> dict[str, Any]:
+    """Compose the narrative via `ClaudeRouter.narrate("adhoc_slt", ...)`.
 
-    Intentionally not calling ClaudeRouter yet — narrative composition lands
-    in a later drop (see module docstring). The text still summarizes the
-    headline so O has something reviewable even without Claude in the path.
+    The structural fallback (used when no API key / API error) preserves
+    `PLACEHOLDER_TAG` whenever scoring is sparse. When Claude does write
+    prose but the snapshot is still first-gen, we append the tag so the
+    honesty signal survives.
     """
     r = ctx.rollup
     if ctx.row_count == 0:
-        body = (
+        fallback = (
             f"No pipeline data available for {ctx.quarter.label}. "
             "The morning snapshot cron may not have run yet, or the DB is empty. "
             f"{PLACEHOLDER_TAG}"
         )
     elif ctx.placeholder:
-        body = (
+        fallback = (
             f"Rollup for {ctx.quarter.label} reflects {ctx.row_count} deals from "
             f"the latest snapshot ({ctx.snapshot_date}). Most rows are UNSCORED — "
             "commit / best-case numbers are structural rollups only and will tighten "
             f"once the scoring pass lands. {PLACEHOLDER_TAG}"
         )
     else:
-        body = (
+        fallback = (
             f"Rollup for {ctx.quarter.label}: ${r.commit_amount:,.0f} commit, "
             f"${r.best_case_amount:,.0f} best case, ${r.weighted_amount:,.0f} weighted "
-            f"across {r.deal_count} deals. {PLACEHOLDER_TAG}"
+            f"across {r.deal_count} deals."
         )
-    return {"type": "section", "text": {"type": "mrkdwn", "text": f"*Narrative*\n{body}"}}
+
+    top = max(ctx.scored_deals, key=lambda d: d.weighted_acv, default=None)
+    top_str = ""
+    if top is not None:
+        top_str = (
+            f"Top weighted deal: {top.opp_name} ({top.owner_name or '?'}, "
+            f"stage {top.stage}, ACV ${(top.acv or 0):,.0f})."
+        )
+    stale_count = sum(
+        1 for d in ctx.scored_deals
+        if "stale" in d.risk_flags or "no_activity" in d.risk_flags
+    )
+    snap_str = (
+        f"latest snapshot {ctx.snapshot_date.isoformat()} ({ctx.row_count} deals)"
+        if ctx.snapshot_date
+        else "no snapshot available"
+    )
+    prompt = (
+        f"Ad-hoc forecast for {ctx.quarter.label}, as of {ctx.as_of.isoformat()}, "
+        f"{snap_str}. "
+        f"Commit ${r.commit_amount:,.0f}, best case ${r.best_case_amount:,.0f}, "
+        f"weighted ${r.weighted_amount:,.0f} across {r.deal_count} deals. "
+        f"{top_str} "
+        f"{stale_count} deals flagged stale or inactive. "
+        f"Placeholder/unscored: {ctx.placeholder}. "
+        "Write the ad-hoc forecast narrative."
+    )
+
+    narrative_text = router.narrate(
+        "adhoc_slt",
+        system=_ADHOC_SLT_SYSTEM,
+        user=prompt,
+        fallback=fallback,
+    )
+    if ctx.placeholder and PLACEHOLDER_TAG not in narrative_text:
+        narrative_text = f"{narrative_text} {PLACEHOLDER_TAG}"
+
+    return {"type": "section", "text": {"type": "mrkdwn", "text": f"*Narrative*\n{narrative_text}"}}
 
 
 # ------------------------------------------------------------------ entry point
 
-def compose_forecast_draft(ctx: ForecastDraftContext) -> dict[str, Any]:
+def compose_forecast_draft(
+    ctx: ForecastDraftContext,
+    *,
+    router: ClaudeRouter | None = None,
+) -> dict[str, Any]:
     """Build the forecast draft payload. Returns `{"text": ..., "blocks": [...]}`."""
+    router = router or ClaudeRouter()
     blocks: list[dict[str, Any]] = [
         _headline_block(ctx),
         {"type": "divider"},
         _top_movers_block(ctx),
         _stale_block(ctx),
         {"type": "divider"},
-        _narrative_block(ctx),
+        _narrative_block(ctx, router=router),
     ]
     summary = (
         f"SLT forecast draft {ctx.quarter.label} · as of {ctx.as_of.isoformat()} · "

--- a/agents/slt_metrics/tests/test_dispatcher_routing.py
+++ b/agents/slt_metrics/tests/test_dispatcher_routing.py
@@ -142,11 +142,17 @@ def test_forecast_accepts_relative_quarter(capture_forecast_dm):
 
 # ---------- forecast narrative composer smoke ----------
 
-def test_forecast_narrative_renders_empty_snapshot():
-    """With no snapshots in the DB, the composer still produces a draft."""
+def test_forecast_narrative_renders_empty_snapshot(monkeypatch):
+    """With no snapshots in the DB, the composer still produces a draft.
+
+    Strip ANTHROPIC_API_KEY so the default router returns the structural
+    fallback (which carries PLACEHOLDER_TAG) without reaching the network.
+    """
     from datetime import date
 
     from agents.slt_metrics.forecast import narrative
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
     ctx = narrative.build_context("FY2026-Q2", today=date(2026, 4, 14))
     draft = narrative.compose_forecast_draft(ctx)
@@ -174,6 +180,72 @@ def test_forecast_narrative_parses_canonical_quarter():
     assert q.fy_year == 2027
     assert q.quarter == 3
     assert q.label == "FY2027-Q3"
+
+
+class _CapturingRouter:
+    """Stub ClaudeRouter that records narrate() kwargs and returns a sentinel."""
+
+    def __init__(self, response: str = "[adhoc_slt] ok"):
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def narrate(self, kind, *, system, user, fallback, max_tokens=None):
+        self.calls.append({
+            "kind": kind, "system": system, "user": user,
+            "fallback": fallback, "max_tokens": max_tokens,
+        })
+        return self.response
+
+
+def test_forecast_narrative_routes_through_claude_router_adhoc_slt():
+    """compose_forecast_draft must invoke the router with kind=adhoc_slt and
+    a prompt carrying the quarter label + commit figure."""
+    from datetime import date
+
+    from agents.slt_metrics.forecast import narrative
+
+    ctx = narrative.build_context("FY2026-Q2", today=date(2026, 4, 14))
+    stub = _CapturingRouter(response="Ad-hoc forecast prose from Claude.")
+    out = narrative.compose_forecast_draft(ctx, router=stub)
+
+    assert len(stub.calls) == 1
+    call = stub.calls[0]
+    assert call["kind"] == "adhoc_slt"
+    assert "Agent 6" in call["system"] and "SLT" in call["system"]
+    assert "FY2026-Q2" in call["user"]
+    assert "Commit $" in call["user"]
+    assert isinstance(call["fallback"], str) and call["fallback"]
+
+    rendered = " ".join(
+        b.get("text", {}).get("text", "")
+        for b in out["blocks"]
+        if b.get("type") == "section"
+    )
+    assert "Ad-hoc forecast prose from Claude." in rendered
+
+
+def test_forecast_narrative_falls_back_preserves_placeholder_tag():
+    """When the router returns the fallback (no key / API error), the
+    rendered narrative block must still carry PLACEHOLDER_TAG for
+    first-gen / unscored snapshots."""
+    from datetime import date
+
+    from agents.slt_metrics.forecast import narrative
+
+    ctx = narrative.build_context("FY2026-Q2", today=date(2026, 4, 14))
+    assert ctx.placeholder is True  # no scored snapshot in test DB
+
+    class _FallbackRouter:
+        def narrate(self, kind, *, system, user, fallback, max_tokens=None):
+            return fallback
+
+    out = narrative.compose_forecast_draft(ctx, router=_FallbackRouter())
+    rendered = " ".join(
+        b.get("text", {}).get("text", "")
+        for b in out["blocks"]
+        if b.get("type") == "section"
+    )
+    assert narrative.PLACEHOLDER_TAG in rendered
 
 
 def test_movers_defaults_to_yesterday():
@@ -301,6 +373,31 @@ def test_dispatch_slt_forecast_subcommand(capture_forecast_dm):
     assert out["quarter"] == "FY2026-Q2"
     assert out["gate_id"] > 0
     assert len(capture_forecast_dm.calls) == 1
+
+
+# ---------- persona alias ----------
+
+def test_persona_alias_urkel_routes_to_slt_metrics():
+    """`@oo urkel ping` resolves through PERSONA_ALIASES to slt_metrics handler."""
+    register_with_dispatcher()
+    out = asyncio.run(dispatch(
+        "<@BOTID> urkel ping", {"user": "U123", "channel": "Cxx"}
+    ))
+    assert "pong" in out["text"].lower()
+    assert "slt_metrics" in out["text"]
+
+
+def test_persona_alias_urkel_matches_canonical_help():
+    """Alias and canonical produce identical help output."""
+    register_with_dispatcher()
+    alias = asyncio.run(dispatch(
+        "<@BOTID> urkel help", {"user": "U123", "channel": "Cxx"}
+    ))
+    canonical = asyncio.run(dispatch(
+        "<@BOTID> slt_metrics help", {"user": "U123", "channel": "Cxx"}
+    ))
+    assert alias["text"] == canonical["text"]
+    assert "urkel" in alias["text"]
 
 
 # ---------- run() lifecycle writes to agent_runs ----------

--- a/agents/top_of_funnel/handler.py
+++ b/agents/top_of_funnel/handler.py
@@ -126,4 +126,5 @@ def _help_text(unknown: str | None = None) -> str:
         "• `queue status` — pending outbound-sequence approval gates\n"
         "• `queue approve <gate_id>` — approve today's enrollment queue\n"
         "• `credits` — Clay credit usage this month\n"
+        "Alias: `@oo outbounder …` routes here too.\n"
     )

--- a/agents/top_of_funnel/tests/test_dispatch.py
+++ b/agents/top_of_funnel/tests/test_dispatch.py
@@ -159,3 +159,35 @@ async def test_help_supports_hyphen_alias():
     r = await a.handle("slack", {"text": "dry-run"})
     # No subcommand 'dry_run' exists → help response.
     assert "Unknown" in r["text"] or "unknown" in r["text"].lower()
+
+
+# ---------------------------------------------------------- persona alias
+
+
+@pytest.mark.asyncio
+async def test_persona_alias_outbounder_routes_to_tof():
+    """`@oo outbounder ping` resolves through shared.slack_dispatcher.PERSONA_ALIASES
+    to the top_of_funnel handler."""
+    from agents.top_of_funnel.main import register_with_dispatcher
+    from shared.slack_dispatcher import dispatch
+
+    register_with_dispatcher()
+    result = await dispatch(
+        "<@UBOT> outbounder ping", {"user": "U_TEST", "channel": "C_TEST"}
+    )
+    assert "pong" in result["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_persona_alias_outbounder_matches_canonical_help():
+    """Alias and canonical produce identical help output."""
+    from agents.top_of_funnel.main import register_with_dispatcher
+    from shared.slack_dispatcher import dispatch
+
+    register_with_dispatcher()
+    alias = await dispatch("<@UBOT> outbounder help", {"user": "U", "channel": "C"})
+    canonical = await dispatch(
+        "<@UBOT> top_of_funnel help", {"user": "U", "channel": "C"}
+    )
+    assert alias["text"] == canonical["text"]
+    assert "outbounder" in alias["text"]

--- a/shared/slack_dispatcher.py
+++ b/shared/slack_dispatcher.py
@@ -24,6 +24,19 @@ ActionHandler = Callable[[dict[str, Any]], Awaitable[dict[str, Any] | None]]
 _registry: dict[str, Handler] = {}
 _action_handlers: dict[str, ActionHandler] = {}
 
+# Human persona names that resolve to canonical agent registry keys. Applied in
+# parse_command() before the registry lookup, so `@oo outbounder enrich` routes
+# to the same handler as `@oo top_of_funnel enrich`. Directories, DB identifiers,
+# Slack log channels, and Monday cards are unchanged — this is dispatcher sugar.
+PERSONA_ALIASES: dict[str, str] = {
+    "outbounder": "top_of_funnel",
+    "closer": "sales_reps",
+    "onboarder": "onboarding",
+    "supporter": "cs",
+    "admin": "revops_support",
+    "urkel": "slt_metrics",
+}
+
 
 def register(agent_name: str, handler: Handler) -> None:
     _registry[agent_name] = handler
@@ -61,7 +74,7 @@ def parse_command(text_in: str) -> tuple[str | None, str]:
     parts = cleaned.split(maxsplit=1)
     if not parts:
         return None, ""
-    first = parts[0].lower()
+    first = PERSONA_ALIASES.get(parts[0].lower(), parts[0].lower())
     if first in _registry and first != "oo":
         return first, parts[1] if len(parts) > 1 else ""
     return None, cleaned

--- a/tests/test_slack_dispatcher.py
+++ b/tests/test_slack_dispatcher.py
@@ -1,8 +1,15 @@
 import asyncio
 import os
 
+import pytest
+
 from shared import slack_dispatcher
-from shared.slack_dispatcher import SlackSender, approval_blocks, parse_command
+from shared.slack_dispatcher import (
+    PERSONA_ALIASES,
+    SlackSender,
+    approval_blocks,
+    parse_command,
+)
 
 
 def test_parse_command_with_agent():
@@ -24,6 +31,48 @@ def test_approval_blocks_shape():
     blocks = approval_blocks(42, "bulk_update_large", "500 accounts")
     assert any(b.get("type") == "actions" for b in blocks)
     assert blocks[-1]["block_id"] == "gate_42"
+
+
+# ------------------------------------------------------------- persona aliases
+
+
+@pytest.fixture
+def _registered_canonicals():
+    """Register the 6 canonical agent names so persona-alias resolution has
+    something to land on. Saves + restores the registry."""
+    saved = dict(slack_dispatcher._registry)
+    slack_dispatcher._registry.clear()
+
+    async def _dummy(payload):  # pragma: no cover - fixture plumbing
+        return {"ok": True}
+
+    for canonical in set(PERSONA_ALIASES.values()):
+        slack_dispatcher.register(canonical, _dummy)
+    yield
+    slack_dispatcher._registry.clear()
+    slack_dispatcher._registry.update(saved)
+
+
+@pytest.mark.parametrize(
+    "persona,canonical",
+    [
+        ("outbounder", "top_of_funnel"),
+        ("closer", "sales_reps"),
+        ("onboarder", "onboarding"),
+        ("supporter", "cs"),
+        ("admin", "revops_support"),
+        ("urkel", "slt_metrics"),
+    ],
+)
+def test_persona_alias_resolves_to_canonical(
+    persona, canonical, _registered_canonicals
+):
+    """parse_command normalizes human persona names to the canonical registry
+    key before routing, so `@oo <persona> <rest>` lands on the same handler as
+    `@oo <canonical> <rest>`."""
+    agent, rest = parse_command(f"<@U0BOT> {persona} some rest text")
+    assert agent == canonical
+    assert rest == "some rest text"
 
 
 def test_dev_guard_redirects_off_target():


### PR DESCRIPTION
## Summary

Dispatcher-level persona aliases for the 6 specialists — zero directory moves, DB migrations, or Monday card renames.

- `outbounder` → `top_of_funnel`
- `closer` → `sales_reps`
- `onboarder` → `onboarding`
- `supporter` → `cs`
- `admin` → `revops_support`
- `urkel` → `slt_metrics`

Single change in ``shared/slack_dispatcher.py:parse_command`` normalizes persona → canonical key before the registry lookup. Help-text updates in each specialist so persona names surface in ``@oo <canonical> help``.

## Why this over the full rename plan

The deferred ``agent_rename_plan.md`` covers directory moves, ``agent_runs.agent_name`` migration, launchd label changes, and Monday card renames — too much blast radius for the ergonomic win of human-readable names. Persona aliases give the same user-facing ergonomics at ~250 LOC with zero infra churn. The full rename stays on disk as an option.

## Context for reviewer

Commit ``1ea5039`` (narrate forecast drafts via ClaudeRouter) inadvertently included 2 of this branch's slt_metrics persona tests. Those tests reference ``PERSONA_ALIASES`` which doesn't exist on main yet — so main is currently red for those 2 tests. Merging this PR resolves that.

## Test plan

- [x] ``pytest`` — 1,544 passed, 7 skipped on branch (same count as ``1ea5039``)
- [x] 18 persona tests added:
  - 6 parametrized ``parse_command`` resolution tests in ``tests/test_slack_dispatcher.py``
  - 2 round-trip tests per specialist (alias routes through ``dispatch()`` + alias/canonical return identical help)
- [ ] Merge to main — confirms the 2 urkel tests from ``1ea5039`` go green
- [ ] OO daemon smoke on Mini: ``@oo outbounder ping`` through ``@oo urkel ping``

Tag: ``v0.7-persona-aliases`` on branch tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)