### PR TITLE
feat(slack): SDR auto-enrichment file ingest in OO dispatcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,5 +53,16 @@ JACKIE_SLACK_USER_ID=REPLACE
 # Channel used for Mark Churned + churn outreach + CSM reassignment approvals.
 CS_JACKIE_CHANNEL=#agent-cs-log
 
+# --- SDR auto enrichment (replaces legacy Zapier flow) ---
+# C... channel ID of the channel the OO daemon watches for file uploads. When
+# set, @app.event("file_shared") is registered and dedupe+enrichment runs on
+# every CSV/XLSX dropped there. Leave unset to disable the feature entirely.
+SDR_ENRICHMENT_CHANNEL=
+# Absolute path to loop-prospecting-engine checkout (pipeline subprocess host).
+# Default works on the Mini; MBP would use /Users/ottimate/loop-prospecting-engine.
+LOOP_PROSPECTING_ENGINE_PATH=/Users/jarvis/loop-prospecting-engine
+# Reject file uploads larger than this. MB; default 25.
+SDR_ENRICHMENT_MAX_MB=25
+
 # --- GCP (Phase 4) ---
 # GCP_PROJECT=loop-revops-agents

--- a/shared/file_ingest.py
+++ b/shared/file_ingest.py
@@ -1,0 +1,202 @@
+"""SDR auto-enrichment file ingest — replaces the legacy Zapier flow.
+
+Registered from `shared.slack_dispatcher.build_app` via `@app.event("file_shared")`.
+When a CSV/XLSX is dropped in the configured SDR channel, this module downloads
+the file, runs the loop-prospecting-engine enrichment pipeline against it via
+subprocess, and posts the cleaned XLSX back in-thread.
+
+Env:
+  SDR_ENRICHMENT_CHANNEL      required; C... channel ID; handler no-ops if unset
+  LOOP_PROSPECTING_ENGINE_PATH optional; defaults to /Users/jarvis/loop-prospecting-engine
+  SDR_ENRICHMENT_MAX_MB        optional; defaults to 25
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import httpx
+from slack_sdk.web.async_client import AsyncWebClient
+
+from shared.secrets import get_config, require_secret
+
+log = logging.getLogger(__name__)
+
+SUPPORTED_EXT = {".csv", ".xlsx", ".xls"}
+DEFAULT_MAX_MB = 25
+SUBPROC_TIMEOUT_SEC = 30 * 60
+
+
+def is_enabled() -> bool:
+    return bool(_target_channel())
+
+
+def _target_channel() -> str | None:
+    chan = get_config("SDR_ENRICHMENT_CHANNEL", "") or ""
+    return chan if chan.startswith("C") else None
+
+
+def _engine_root() -> Path:
+    return Path(
+        get_config("LOOP_PROSPECTING_ENGINE_PATH", "/Users/jarvis/loop-prospecting-engine")
+    )
+
+
+def _engine_python() -> Path:
+    return _engine_root() / "venv" / "bin" / "python"
+
+
+def _max_bytes() -> int:
+    try:
+        return int(get_config("SDR_ENRICHMENT_MAX_MB", str(DEFAULT_MAX_MB))) * 1024 * 1024
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_MB * 1024 * 1024
+
+
+async def handle_file_shared(client: AsyncWebClient, event: dict[str, Any]) -> None:
+    """Event entry point — call with the Slack event payload.
+
+    Slack has already been ACKed upstream in the dispatcher (explicit early
+    ack) so this coroutine is free to take minutes without re-delivery.
+    """
+    target = _target_channel()
+    if not target:
+        return
+    channel_id = event.get("channel_id")
+    if channel_id != target:
+        return
+
+    file_id = event.get("file_id") or (event.get("file") or {}).get("id")
+    if not file_id:
+        log.warning("file_shared without file_id; payload=%s", event)
+        return
+
+    try:
+        info = await client.files_info(file=file_id)
+    except Exception:
+        log.exception("files.info failed for %s", file_id)
+        return
+    file_data = (info.data or {}).get("file", {}) if hasattr(info, "data") else info.get("file", {})
+    filename = file_data.get("name", "") or ""
+    ext = Path(filename).suffix.lower()
+    if ext not in SUPPORTED_EXT:
+        return
+    size = int(file_data.get("size") or 0)
+    max_bytes = _max_bytes()
+    if size > max_bytes:
+        await client.chat_postMessage(
+            channel=channel_id,
+            thread_ts=event.get("event_ts"),
+            text=f":x: `{filename}` is {size / 1024 / 1024:.1f}MB — over the {max_bytes // 1024 // 1024}MB limit.",
+        )
+        return
+
+    thread_ts = _resolve_thread_ts(file_data, channel_id, event)
+
+    await client.chat_postMessage(
+        channel=channel_id,
+        thread_ts=thread_ts,
+        text=f":broom: Picked up `{filename}` — dedupe + enrichment starting, ~1–5 min.",
+    )
+
+    download_url = file_data.get("url_private_download") or file_data.get("url_private") or ""
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(
+        None, _run_pipeline_sync, download_url, filename, channel_id, thread_ts
+    )
+
+
+def _resolve_thread_ts(file_data: dict[str, Any], channel_id: str, event: dict[str, Any]) -> str:
+    shares = file_data.get("shares") or {}
+    for bucket in ("public", "private"):
+        lst = (shares.get(bucket) or {}).get(channel_id) or []
+        if lst:
+            ts = lst[0].get("ts")
+            if ts:
+                return ts
+    return event.get("event_ts") or ""
+
+
+def _run_pipeline_sync(
+    download_url: str,
+    filename: str,
+    channel_id: str,
+    thread_ts: str,
+) -> None:
+    """Blocking path — runs on a worker thread."""
+    from slack_sdk import WebClient
+
+    token = require_secret("SLACK_BOT_TOKEN")
+    web = WebClient(token=token)
+
+    def say(text: str) -> None:
+        try:
+            web.chat_postMessage(channel=channel_id, thread_ts=thread_ts, text=text)
+        except Exception:
+            log.exception("chat_postMessage failed")
+
+    if not download_url:
+        say(":x: No download URL on the shared file.")
+        return
+
+    engine = _engine_root()
+    py = _engine_python()
+    if not py.exists():
+        say(f":x: Pipeline not available: venv missing at `{py}`.")
+        return
+
+    try:
+        resp = httpx.get(
+            download_url,
+            headers={"Authorization": f"Bearer {token}"},
+            follow_redirects=True,
+            timeout=60,
+        )
+    except Exception as e:
+        say(f":x: Download failed: {type(e).__name__}: {e}")
+        return
+    if resp.status_code != 200:
+        say(f":x: Download HTTP {resp.status_code}.")
+        return
+
+    with tempfile.TemporaryDirectory(prefix="sdr_enrich_") as tmpdir:
+        src = Path(tmpdir) / filename
+        src.write_bytes(resp.content)
+
+        try:
+            proc = subprocess.run(
+                [str(py), "main.py", "--test", str(src)],
+                cwd=str(engine),
+                capture_output=True,
+                text=True,
+                timeout=SUBPROC_TIMEOUT_SEC,
+            )
+        except subprocess.TimeoutExpired:
+            say(f":x: Pipeline timed out after {SUBPROC_TIMEOUT_SEC // 60} min.")
+            return
+
+        if proc.returncode != 0:
+            tail = (proc.stderr or proc.stdout or "")[-1500:]
+            say(f":x: Pipeline failed (rc={proc.returncode}):\n```{tail}```")
+            return
+
+        result = engine / "data" / f"{Path(filename).stem}_cleaned.xlsx"
+        if not result.exists():
+            tail = (proc.stdout or "")[-800:]
+            say(f":x: Output not produced. Stdout tail:\n```{tail}```")
+            return
+
+        try:
+            web.files_upload_v2(
+                channel=channel_id,
+                thread_ts=thread_ts,
+                file=str(result),
+                filename=result.name,
+                initial_comment=f":white_check_mark: Dedup + enrich complete for `{filename}`",
+            )
+        except Exception as e:
+            say(f":x: Upload failed: {type(e).__name__}: {e}")

--- a/shared/file_ingest.py
+++ b/shared/file_ingest.py
@@ -16,6 +16,7 @@ import asyncio
 import logging
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +30,26 @@ log = logging.getLogger(__name__)
 SUPPORTED_EXT = {".csv", ".xlsx", ".xls"}
 DEFAULT_MAX_MB = 25
 SUBPROC_TIMEOUT_SEC = 30 * 60
+
+# Slack fires file_shared multiple times per upload (once on creation, again on
+# channel share). Dedup by file_id for a short window so we only run the pipeline
+# once per upload.
+_DEDUP_TTL_SEC = 600
+_seen_file_ids: dict[str, float] = {}
+_dedup_lock = asyncio.Lock()
+
+
+async def _claim_file_id(file_id: str) -> bool:
+    """Return True if this invocation should process the file; False if already claimed."""
+    async with _dedup_lock:
+        now = time.monotonic()
+        # Expire stale entries in-line — cheap (few entries) and lock-safe.
+        for fid in [k for k, t in _seen_file_ids.items() if now - t > _DEDUP_TTL_SEC]:
+            del _seen_file_ids[fid]
+        if file_id in _seen_file_ids:
+            return False
+        _seen_file_ids[file_id] = now
+        return True
 
 
 def is_enabled() -> bool:
@@ -73,6 +94,10 @@ async def handle_file_shared(client: AsyncWebClient, event: dict[str, Any]) -> N
     file_id = event.get("file_id") or (event.get("file") or {}).get("id")
     if not file_id:
         log.warning("file_shared without file_id; payload=%s", event)
+        return
+
+    if not await _claim_file_id(file_id):
+        log.info("file_ingest: duplicate file_shared for %s — skipping", file_id)
         return
 
     try:

--- a/shared/slack_dispatcher.py
+++ b/shared/slack_dispatcher.py
@@ -207,6 +207,18 @@ def build_app() -> Any:
             result = _error_reply(text_in, e)
         await say(text=_render(result), thread_ts=thread_ts)
 
+    from shared.file_ingest import handle_file_shared, is_enabled as _file_ingest_enabled
+
+    if _file_ingest_enabled():
+        @app.event("file_shared")
+        async def _on_file_shared(ack, event, client):
+            # ACK immediately — enrichment subprocess can take minutes.
+            await ack()
+            try:
+                await handle_file_shared(client, event)
+            except Exception:
+                log.exception("file_shared handler failed for event=%s", event)
+
     @app.action("approve_gate")
     async def _approve(ack, body, client):
         await ack()

--- a/tests/test_file_ingest.py
+++ b/tests/test_file_ingest.py
@@ -1,0 +1,103 @@
+"""Unit tests for shared.file_ingest — SDR auto-enrichment handler guards.
+
+Subprocess + network paths are covered by smoke tests, not unit tests.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def disabled_env(monkeypatch):
+    monkeypatch.delenv("SDR_ENRICHMENT_CHANNEL", raising=False)
+
+
+@pytest.fixture
+def enabled_env(monkeypatch):
+    monkeypatch.setenv("SDR_ENRICHMENT_CHANNEL", "C_SDR")
+
+
+def test_is_enabled_false_without_env(disabled_env):
+    from shared import file_ingest
+
+    assert file_ingest.is_enabled() is False
+
+
+def test_is_enabled_false_with_non_channel_id(monkeypatch):
+    monkeypatch.setenv("SDR_ENRICHMENT_CHANNEL", "lead-drops")
+    from shared import file_ingest
+
+    assert file_ingest.is_enabled() is False
+
+
+def test_is_enabled_true_when_channel_id(enabled_env):
+    from shared import file_ingest
+
+    assert file_ingest.is_enabled() is True
+
+
+async def test_handler_noop_when_disabled(disabled_env):
+    from shared.file_ingest import handle_file_shared
+
+    client = MagicMock()
+    client.files_info = AsyncMock()
+    client.chat_postMessage = AsyncMock()
+
+    await handle_file_shared(client, {"channel_id": "C_SDR", "file_id": "F1"})
+
+    client.files_info.assert_not_called()
+    client.chat_postMessage.assert_not_called()
+
+
+async def test_handler_noop_on_wrong_channel(enabled_env):
+    from shared.file_ingest import handle_file_shared
+
+    client = MagicMock()
+    client.files_info = AsyncMock()
+    client.chat_postMessage = AsyncMock()
+
+    await handle_file_shared(client, {"channel_id": "C_OTHER", "file_id": "F1"})
+
+    client.files_info.assert_not_called()
+    client.chat_postMessage.assert_not_called()
+
+
+async def test_handler_noop_on_unsupported_extension(enabled_env):
+    from shared.file_ingest import handle_file_shared
+
+    client = MagicMock()
+    client.files_info = AsyncMock(
+        return_value=SimpleNamespace(data={"file": {"name": "report.pdf", "size": 1024}})
+    )
+    client.chat_postMessage = AsyncMock()
+
+    await handle_file_shared(client, {"channel_id": "C_SDR", "file_id": "F1"})
+
+    client.files_info.assert_awaited_once()
+    client.chat_postMessage.assert_not_called()
+
+
+async def test_handler_rejects_oversize(enabled_env, monkeypatch):
+    monkeypatch.setenv("SDR_ENRICHMENT_MAX_MB", "1")
+    from shared import file_ingest
+    from shared.file_ingest import handle_file_shared
+
+    assert file_ingest._max_bytes() == 1024 * 1024
+
+    client = MagicMock()
+    client.files_info = AsyncMock(
+        return_value=SimpleNamespace(
+            data={"file": {"name": "big.csv", "size": 5 * 1024 * 1024}}
+        )
+    )
+    client.chat_postMessage = AsyncMock()
+
+    await handle_file_shared(client, {"channel_id": "C_SDR", "file_id": "F1"})
+
+    client.files_info.assert_awaited_once()
+    client.chat_postMessage.assert_awaited_once()
+    call_args = client.chat_postMessage.await_args
+    assert "over the" in call_args.kwargs["text"]

--- a/tests/test_file_ingest.py
+++ b/tests/test_file_ingest.py
@@ -10,6 +10,15 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _clear_dedup():
+    from shared import file_ingest as _fi
+
+    _fi._seen_file_ids.clear()
+    yield
+    _fi._seen_file_ids.clear()
+
+
 @pytest.fixture
 def disabled_env(monkeypatch):
     monkeypatch.delenv("SDR_ENRICHMENT_CHANNEL", raising=False)
@@ -78,6 +87,25 @@ async def test_handler_noop_on_unsupported_extension(enabled_env):
 
     client.files_info.assert_awaited_once()
     client.chat_postMessage.assert_not_called()
+
+
+async def test_handler_dedups_duplicate_file_shared(enabled_env):
+    # Slack fires file_shared multiple times per upload; make sure we only
+    # process each file_id once.
+    from shared.file_ingest import handle_file_shared
+
+    client = MagicMock()
+    client.files_info = AsyncMock(
+        return_value=SimpleNamespace(data={"file": {"name": "report.pdf", "size": 1024}})
+    )
+    client.chat_postMessage = AsyncMock()
+
+    # Extension filter will skip these, but the claim happens earlier so the
+    # second call should not reach files_info.
+    await handle_file_shared(client, {"channel_id": "C_SDR", "file_id": "FDUP"})
+    await handle_file_shared(client, {"channel_id": "C_SDR", "file_id": "FDUP"})
+
+    assert client.files_info.await_count == 1
 
 
 async def test_handler_rejects_oversize(enabled_env, monkeypatch):


### PR DESCRIPTION
## Summary
- Replaces the legacy **Zapier SDR auto-enrichment flow** by wiring `file_shared` ingestion directly into the OO dispatcher. One Slack app (`@outbounder`), one Socket Mode connection, no event contention.
- New module `shared/file_ingest.py` — downloads the file, runs `loop-prospecting-engine/main.py --test` via subprocess, uploads the cleaned XLSX back in-thread.
- New feature flag: `SDR_ENRICHMENT_CHANNEL` env var. When unset, the handler is not registered and the daemon behaves identically to today.

## Why in the OO daemon and not a sibling bot
Running a second Socket Mode client on the `@outbounder` app would round-robin events — ~50% of every `@oo` command would be swallowed by the sibling bot. This approach keeps all Slack events on the OO daemon's single dispatcher.

## Cutover plan
1. In api.slack.com/apps → `@outbounder` app → Event Subscriptions → add bot event `file_shared` → Save → reinstall to workspace.
2. Invite `@outbounder` to the SDR auto enrichment channel.
3. Set `SDR_ENRICHMENT_CHANNEL=C0...` in `~/loop-revops-agents/.env` on Mini.
4. `launchctl kickstart -k gui/\$(id -u)/com.loop-revops.oo-daemon`.
5. Smoke test: drop a test CSV in the channel, verify enriched XLSX returns in-thread.
6. Decommission the standalone `com.loop.prospecting.slack-bot` launchd service.

## Test plan
- [x] 7 unit tests in `tests/test_file_ingest.py` — channel filter, extension filter, size cap guards
- [x] 39 regression tests on dispatcher + internals still pass (local + Mini)
- [ ] End-to-end smoke test with a real CSV drop in the SDR channel (blocked on cutover steps 1-3)
- [ ] 1-hour soak under normal OO traffic (monitor `@oo` commands still work)

## Rollback
Set `SDR_ENRICHMENT_CHANNEL=` (empty) + restart OO daemon → handler is not registered, behavior reverts to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)